### PR TITLE
カメラのポストエフェクトをOFF

### DIFF
--- a/src/Assets/Scenes/3 PingPong Scene.unity
+++ b/src/Assets/Scenes/3 PingPong Scene.unity
@@ -423,7 +423,7 @@ MonoBehaviour:
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
   m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 1
+  m_RenderPostProcessing: 0
   m_Antialiasing: 1
   m_AntialiasingQuality: 2
   m_StopNaN: 1


### PR DESCRIPTION
テクスチャを作成しているカメラのポストエフェクトがONになっていて、ビネット効果（画面中心から外れるほど暗くなる）等によって前のフレームの画像が暗く合成されているようでした。

ひとまず、ポストエフェクトを外しました（テクスチャ作成用のカメラのCameraコンポーネントのRenderingのPost Processing のチェックを外す）が、テクスチャがぶつぶつにレンダリングされているので、まだ怪しいものがあるかもしれません。

![post_off](https://github.com/simulacru/PGWS4_6_render_texture/assets/936545/659165b9-0211-4104-bf4f-732c41b11316)
